### PR TITLE
use relative reference to use renderer as a library

### DIFF
--- a/src/renderer/renderer.py
+++ b/src/renderer/renderer.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from pytorch3d.structures import Meshes
 from pytorch3d.io import load_obj
 from pytorch3d.renderer.mesh import rasterize_meshes
-from src.renderer.util import face_vertices, vertex_normals, batch_orth_proj
+from .util import face_vertices, vertex_normals, batch_orth_proj
 import pickle
 
 def keep_vertices_and_update_faces(faces, vertices_to_keep):


### PR DESCRIPTION
This PR enables the renderer to be used as a library when in another project. The "src" import can conflict with a common folder name.